### PR TITLE
Looking to limit the max SMS and MMS default size. 500 and 100 are big a...

### DIFF
--- a/overlay/packages/apps/Mms/res/xml/mms_config.xml
+++ b/overlay/packages/apps/Mms/res/xml/mms_config.xml
@@ -31,6 +31,12 @@
 
     <!-- Maximum width for an attached image -->
     <int name="maxImageWidth">1280</int>
+    
+    <!-- Default SMS messages per thread -->
+    <int name="defaultSMSMessagesPerThread">250</int>
+    
+    <!-- Default MMS messages per thread -->
+    <int name="defaultMMSMessagesPerThread">25</int>
 
     <!-- UAProf URL -->
     <string name="uaProfUrl">http://device.sprintpcs.com/Samsung/SPH-D720/latest</string>


### PR DESCRIPTION
...nd I think users would prefer to keep the default levels lower to save time when backing up and restoring SMS and MMS messages after a data wipe.
